### PR TITLE
Feature fix match trust file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ fapolicyd::trust_file { 'myapp':
 }
 ```
 
+Note: If an application being whitelisted does not currently exist on a machine, the trust file will instead include a comment.  Once the application does exist on the machine, the comment will be updated to be a trusted application on the next Puppet run.  The comment included will be similar to the following:
+
+```bash
+#<application path> is trusted but does not currently exist on the machine
+```
+
 For more information regarding trust files, refer to the Red Hat Enterprise Linux documentation for [Marking files as trusted using an additional source of trust][3]
 
 ### Whitelist applications using a rule file under `/etc/fapolicyd/rules.d/`

--- a/manifests/trust_file.pp
+++ b/manifests/trust_file.pp
@@ -30,7 +30,7 @@ define fapolicyd::trust_file (
       ensure => present,
       path   => $trusted_file_path,
       line   => Deferred('fapolicyd::get_trusted_file_info', [$trusted_app]),
-      match  => "^${trusted_app}|^# ${trusted_app}",
+      match  => "^${trusted_app}|^#${trusted_app}",
       notify => Service['fapolicyd'],
     }
   }


### PR DESCRIPTION
- Fix the match condition for adding lines into a trust file
- Add note in README regarding how trusted applications are added to the trust file as comments if they do not exist on the machine